### PR TITLE
Remove letter O and add 挂 plate type

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -56,7 +56,6 @@ const alphabets = [
     'T',
     'Y',
     'U',
-    'O',
     'P',
   ],
   [
@@ -86,4 +85,5 @@ const specials = [
   '警',
   '港',
   '澳',
+  '挂',
 ];

--- a/lib/src/plate_keyboard.dart
+++ b/lib/src/plate_keyboard.dart
@@ -117,17 +117,8 @@ class _PlateKeyboardState extends State<PlateKeyboard> {
           (element) => keys.add(_buildKeyboardButton(element, index > 1)));
 
       /// 字母 Q ~ P
-      alphabets[0].forEach((element) {
-        if (element != 'O') {
-          keys.add(_buildKeyboardButton(element, true));
-        } else if ('O' == element) {
-          if (index < 5) {
-            keys.add(_buildKeyboardButton(element, true));
-          } else if (5 == index) {
-            keys.add(_buildKeyboardButton(element, false));
-          }
-        }
-      });
+      alphabets[0]
+          .forEach((element) => keys.add(_buildKeyboardButton(element, true)));
       if (index > 5) {
         keys.add(_buildKeyboardButton(specials[0], true));
       }
@@ -151,6 +142,9 @@ class _PlateKeyboardState extends State<PlateKeyboard> {
 
       /// 澳
       keys.add(_buildKeyboardButton(specials[4], index >= 6));
+
+      /// 挂
+      keys.add(_buildKeyboardButton(specials[5], index >= 6));
     }
 
     /// 退格


### PR DESCRIPTION
## Summary
- remove disallowed letter O from keyboard constants
- support 挂 as an additional special plate type and add it to the keyboard

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*
- `dart format .` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954877139883238878cd00100bafc8